### PR TITLE
Temporarily disable after_prepare hook

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -17,7 +17,7 @@
 
 	<asset src="www/task/AppPreferences.js" target="task/AppPreferences.js" />
 	
-	<hook type="after_prepare" src="bin/after_prepare.js" />
+	<!-- <hook type="after_prepare" src="bin/after_prepare.js" /> -->
 	<hook type="after_plugin_add" src="bin/after_plugin_add.js" />
 	<hook type="before_plugin_rm" src="bin/before_plugin_rm.js" />
 


### PR DESCRIPTION
Temporarily disable after_prepare hook to make the plugin install
correct.

After adding the plugin or a platform enable the hook and you should be
good to go.
